### PR TITLE
Persist changes in volume and pan to core data

### DIFF
--- a/Play Secuence.xcodeproj/project.pbxproj
+++ b/Play Secuence.xcodeproj/project.pbxproj
@@ -604,6 +604,8 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Play-Secuence--iOS--Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = "Multitrack Player";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.music";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UIRequiresFullScreen = NO;
@@ -636,6 +638,8 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Play-Secuence--iOS--Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = "Multitrack Player";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.music";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UIRequiresFullScreen = NO;

--- a/Play Secuence.xcodeproj/xcuserdata/esteban.trivino.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/Play Secuence.xcodeproj/xcuserdata/esteban.trivino.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -8,14 +8,14 @@
          BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
          <BreakpointContent
             uuid = "36A5CD9C-E467-4FB0-9056-EFCA199DD029"
-            shouldBeEnabled = "No"
+            shouldBeEnabled = "Yes"
             ignoreCount = "0"
             continueAfterRunningActions = "No"
             filePath = "iOS/Ui/ViewModel/TrackControl/TrackControlViewModel.swift"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "26"
-            endingLineNumber = "26"
+            startingLineNumber = "28"
+            endingLineNumber = "28"
             landmarkName = "buildPlayer(track:)"
             landmarkType = "7">
          </BreakpointContent>

--- a/Play Secuence.xcodeproj/xcuserdata/esteban.trivino.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/Play Secuence.xcodeproj/xcuserdata/esteban.trivino.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -7,16 +7,16 @@
       <BreakpointProxy
          BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
          <BreakpointContent
-            uuid = "36A5CD9C-E467-4FB0-9056-EFCA199DD029"
+            uuid = "4977FE60-B3CC-44B4-9A09-ACD3A32302FD"
             shouldBeEnabled = "Yes"
             ignoreCount = "0"
             continueAfterRunningActions = "No"
             filePath = "iOS/Ui/ViewModel/TrackControl/TrackControlViewModel.swift"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "28"
-            endingLineNumber = "28"
-            landmarkName = "buildPlayer(track:)"
+            startingLineNumber = "74"
+            endingLineNumber = "74"
+            landmarkName = "toogleMute()"
             landmarkType = "7">
          </BreakpointContent>
       </BreakpointProxy>

--- a/iOS/Model/CoreDataManager/Multitrack/CoreDataMultitrackManager.swift
+++ b/iOS/Model/CoreDataManager/Multitrack/CoreDataMultitrackManager.swift
@@ -65,6 +65,7 @@ class CoreDataMultitrackManager {// Get Core Data managed object context
                 trackDao.relativePath = track.relativePath
                 trackDao.volume = track.config.volume
                 trackDao.pan = track.config.pan
+                trackDao.mute = track.config.isMuted
                 self.commit()
             }
         } catch {
@@ -99,5 +100,21 @@ class CoreDataMultitrackManager {// Get Core Data managed object context
             self.context.delete(multitrackDao)
         }
         self.commit()
+    }
+    
+    func deleteMultitrack(_ multitrackId: UUID) {
+        let fetchRequest: NSFetchRequest<MultitrackDao> = MultitrackDao.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "id == %@", multitrackId as CVarArg)
+        do {
+            if let multitrackDao = try self.context.fetch(fetchRequest).first {
+                self.loadTracks(for: multitrackDao).forEach() { trackDao in
+                    self.context.delete(trackDao)
+                }
+                self.context.delete(multitrackDao)
+                self.commit()
+            }
+        } catch {
+            print("Unable to Delete MultitrackDao in deleteMultitrack, (\(error))")
+        }
     }
 }

--- a/iOS/Model/CoreDataManager/Multitrack/CoreDataMultitrackManager.swift
+++ b/iOS/Model/CoreDataManager/Multitrack/CoreDataMultitrackManager.swift
@@ -54,6 +54,24 @@ class CoreDataMultitrackManager {// Get Core Data managed object context
     }
     
     // MARK: Tracks
+    
+    func updateTrack(_ track: Track) {
+        let fetchRequest: NSFetchRequest<TrackDao> = TrackDao.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "id == %@", track.id as CVarArg)
+        do {
+            if let trackDao = try self.context.fetch(fetchRequest).first {
+                print(trackDao.multitrack?.name ?? "")
+                trackDao.name = track.name
+                trackDao.relativePath = track.relativePath
+                trackDao.volume = track.config.volume
+                trackDao.pan = track.config.pan
+                self.commit()
+            }
+        } catch {
+            print("Unable to Update TrackDao in updateTrack, (\(error))")
+        }
+    }
+    
     func saveTracks(_ tracks: [Track], for multitrack: MultitrackDao) {
         tracks.forEach() { track in
             _ = track.mapToTrackDao(context: self.context, with: multitrack)
@@ -66,9 +84,9 @@ class CoreDataMultitrackManager {// Get Core Data managed object context
         fetchRequest.predicate = NSPredicate(format: "multitrack == %@", multitrack)
         do {
             tracks = try self.context.fetch(fetchRequest)
-            tracks.forEach() { print($0.multitrack?.name) }
+            tracks.forEach() { print($0.multitrack?.name ?? "") }
         } catch {
-            print("Unable to Fetch Workouts, (\(error))")
+            print("Unable to Fetch TrackDaos in loadTracks, (\(error))")
         }
         return tracks
     }

--- a/iOS/Model/Repository/Multitrack/MultitrackLocalRepository.swift
+++ b/iOS/Model/Repository/Multitrack/MultitrackLocalRepository.swift
@@ -36,8 +36,8 @@ class MultitrackLocalRepository: MultitrackRepository {
         Multitrack(id: id, name: "", tracks: [])
     }
     
-    func deleteMultitrack(_ multitrack: Multitrack) {
-        self.dataManager.deleteMultitrack(multitrack.id)
+    func deleteMultitrack(_ multitrackId: UUID) {
+        self.dataManager.deleteMultitrack(multitrackId)
         self.dataManager.commit()
     }
 }

--- a/iOS/Model/Repository/Multitrack/MultitrackLocalRepository.swift
+++ b/iOS/Model/Repository/Multitrack/MultitrackLocalRepository.swift
@@ -37,6 +37,7 @@ class MultitrackLocalRepository: MultitrackRepository {
     }
     
     func deleteMultitrack(_ multitrack: Multitrack) {
-        
+        self.dataManager.deleteMultitrack(multitrack.id)
+        self.dataManager.commit()
     }
 }

--- a/iOS/Model/Repository/MultitrackRepository.swift
+++ b/iOS/Model/Repository/MultitrackRepository.swift
@@ -11,5 +11,5 @@ protocol MultitrackRepository {
     func saveMultitrack(_ multitrack: Multitrack)
     func loadMultitracks() -> Dictionary<UUID, Multitrack>
     func loadMultitrack(id: UUID) -> Multitrack
-    func deleteMultitrack(_ multitrack: Multitrack)
+    func deleteMultitrack(_ multitrackId: UUID)
 }

--- a/iOS/Model/Sequences.xcdatamodeld/Sequences.xcdatamodel/contents
+++ b/iOS/Model/Sequences.xcdatamodeld/Sequences.xcdatamodel/contents
@@ -6,6 +6,7 @@
     </entity>
     <entity name="TrackDao" representedClassName="TrackDao" syncable="YES" codeGenerationType="class">
         <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="mute" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="name" optional="YES" attributeType="String"/>
         <attribute name="pan" optional="YES" attributeType="Float" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="relativePath" optional="YES" attributeType="String"/>

--- a/iOS/Model/Track/Track.swift
+++ b/iOS/Model/Track/Track.swift
@@ -17,6 +17,11 @@ struct Track: Identifiable {
     struct Config {
         var pan: Float
         var volume: Float
+        var isMuted: Bool
+        
+        var volumeWithMute: Float {
+            isMuted ? 0 : volume
+        }
     }
 }
 
@@ -35,6 +40,6 @@ extension Track {
 
 extension TrackDao {
     func mapToTrack() -> Track {
-        Track(id: self.id ?? UUID(), name: self.name ?? "", relativePath: self.relativePath ?? "", config: .init(pan: self.pan, volume: self.volume))
+        Track(id: self.id ?? UUID(), name: self.name ?? "", relativePath: self.relativePath ?? "", config: .init(pan: self.pan, volume: self.volume, isMuted: self.mute))
     }
 }

--- a/iOS/Ui/View/Dashboard/DashboardScreen.swift
+++ b/iOS/Ui/View/Dashboard/DashboardScreen.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct DashboardScreen: View {
     @State private var showPicker: Bool = false
     @StateObject var viewModel = DashboardViewModel()
+    @State private var presentModalDelete: Bool = false
     
     var body: some View {
         VStack(spacing: 0) {
@@ -59,6 +60,11 @@ struct DashboardScreen: View {
                 self.viewModel.createMultitrack(with: urls)
             }
         }
+        .confirmationDialog("¿Deseas eliminar el multitrack?", isPresented: self.$presentModalDelete) {
+            Button("Eliminar multitrack", role: .destructive) {
+                self.viewModel.deleteSelectedMultitrack()
+            }
+        }
     }
     
     @ViewBuilder
@@ -83,6 +89,18 @@ struct DashboardScreen: View {
                     .resizable()
                     .scaledToFit()
                     .frame(height: 30, alignment: .center)
+            }
+            if let _ = self.viewModel.selectedMultitrackIndex {
+                Spacer()
+                Button(action: {
+                    self.presentModalDelete.toggle()
+                }) {
+                    Image(systemName: "trash")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(height: 30, alignment: .center)
+                        .foregroundColor(.red)
+                }
             }
         }
     }

--- a/iOS/Ui/View/Dashboard/DashboardScreen.swift
+++ b/iOS/Ui/View/Dashboard/DashboardScreen.swift
@@ -92,8 +92,8 @@ struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
         let viewModel = DashboardViewModel()
         let id1 = UUID()
-        viewModel.multitracks[id1] = (.init(id: id1, name: "Rey de reyes", tracks: [.init(id: UUID(), name: "Click", relativePath: "", config: .init(pan: 0, volume: 0.5))]))
-        viewModel.appendTrackController(using: Track(id: UUID(), name: "Click", relativePath: "", config: .init(pan: -1, volume: 0.5)) )
+        viewModel.multitracks[id1] = (.init(id: id1, name: "Rey de reyes", tracks: [.init(id: UUID(), name: "Click", relativePath: "", config: .init(pan: 0, volume: 0.5, isMuted: false))]))
+        viewModel.appendTrackController(using: Track(id: UUID(), name: "Click", relativePath: "", config: .init(pan: -1, volume: 0.5, isMuted: false)) )
         return DashboardScreen(viewModel: viewModel)
             .previewInterfaceOrientation(.landscapeLeft)
     }

--- a/iOS/Ui/View/SequenceControls/SequenceControlsScreen.swift
+++ b/iOS/Ui/View/SequenceControls/SequenceControlsScreen.swift
@@ -28,9 +28,9 @@ struct SequenceControlsScreen: View {
 struct Faders_Previews: PreviewProvider {
     static var previews: some View {
         let viewModel = DashboardViewModel()
-        viewModel.appendTrackController(using: Track(id: UUID(), name: "Click", relativePath: "", config: .init(pan: 0, volume: 0.5)))
-        viewModel.appendTrackController(using: Track(id: UUID(), name: "Sequence", relativePath: "", config: .init(pan: 0, volume: 0.5)))
-        viewModel.appendTrackController(using: Track(id: UUID(), name: "Keys", relativePath: "", config: .init(pan: 0, volume: 0.5)))
+        viewModel.appendTrackController(using: Track(id: UUID(), name: "Click", relativePath: "", config: .init(pan: 0, volume: 0.5, isMuted: false)))
+        viewModel.appendTrackController(using: Track(id: UUID(), name: "Sequence", relativePath: "", config: .init(pan: 0, volume: 0.5, isMuted: false)))
+        viewModel.appendTrackController(using: Track(id: UUID(), name: "Keys", relativePath: "", config: .init(pan: 0, volume: 0.5, isMuted: false)))
         return SequenceControlsScreen(viewModel: viewModel)
             .previewInterfaceOrientation(.landscapeLeft)
     }

--- a/iOS/Ui/View/TrackControl/TrackControl.swift
+++ b/iOS/Ui/View/TrackControl/TrackControl.swift
@@ -13,6 +13,14 @@ struct TrackControl: View {
     var body: some View {
         VStack(spacing: 0.0) {
             PanSelector(selectedPan: $viewModel.trackPan)
+            Button(action: {
+                self.viewModel.toogleMute()
+            }, label: {
+                Image(systemName: viewModel.mute ? "speaker.slash.fill" : "speaker.fill")
+                    .resizable()
+                    .frame(width: 20, height: 20)
+            })
+            .padding([.top, .bottom], 5)
             Text(String(format: "%.0f", viewModel.trackVolume))
                 .font(.system(size:12))
             GeometryReader { geo in
@@ -33,7 +41,7 @@ struct TrackControl: View {
 
 struct Fader_Previews: PreviewProvider {
     static var previews: some View {
-        TrackControl(viewModel: TrackControlViewModel(track: Track(id: UUID(), name: "Click", relativePath: "", config: .init(pan: 0, volume: 0.5))))
+        TrackControl(viewModel: TrackControlViewModel(track: Track(id: UUID(), name: "Click", relativePath: "", config: .init(pan: 0, volume: 0.5, isMuted: false))))
             .previewInterfaceOrientation(.landscapeLeft)
     }
 }

--- a/iOS/Ui/ViewModel/Dashboard/DashboardViewModel.swift
+++ b/iOS/Ui/ViewModel/Dashboard/DashboardViewModel.swift
@@ -48,6 +48,12 @@ final class DashboardViewModel: ObservableObject {
         self.multitrackRepository.deleteMultitrack(multitrackId)
     }
     
+    func deleteSelectedMultitrack() {
+        if let selectedMultitrackIndex = self.selectedMultitrackIndex {
+            self.deleteMultitrack(selectedMultitrackIndex)
+        }
+    }
+    
     
     func createMultitrack(with tracksTmpUrls: [URL]) {
         var multitrack = Multitrack(id: UUID(),

--- a/iOS/Ui/ViewModel/TrackControl/TrackControlViewModel.swift
+++ b/iOS/Ui/ViewModel/TrackControl/TrackControlViewModel.swift
@@ -9,6 +9,8 @@ import AVFoundation
 
 class TrackControlViewModel: ObservableObject, Identifiable {
     
+    private let dataManager = CoreDataMultitrackManager()
+    
     private(set) var id: UUID
     private var player: AVAudioPlayer
     private var track: Track
@@ -70,6 +72,7 @@ class TrackControlViewModel: ObservableObject, Identifiable {
         set {
             self.track.config.volume = newValue/100
             self.player.volume = newValue/100
+            self.dataManager.updateTrack(self.track)
             objectWillChange.send()
         }
     }
@@ -81,6 +84,7 @@ class TrackControlViewModel: ObservableObject, Identifiable {
         set {
             self.track.config.pan = newValue.rawValue
             self.player.pan = newValue.rawValue
+            self.dataManager.updateTrack(self.track)
             objectWillChange.send()
         }
     }


### PR DESCRIPTION
- When the user changes the pan and/or volume config, close the app, and launch again, the app will show the last changes made by the user.
- Delete multitrack button added
- Add mute/unmute buton to track control

<img width="1266" height="585" alt="Screenshot 2025-08-21 at 5 18 41 PM" src="https://github.com/user-attachments/assets/895f7051-e93c-416a-8f10-41d872a3b759" />